### PR TITLE
fix(login): Correct messages to match cipbia

### DIFF
--- a/data/scripts/creaturescripts/login.lua
+++ b/data/scripts/creaturescripts/login.lua
@@ -24,16 +24,20 @@ conditionLight:setParameter(CONDITION_PARAM_LIGHT_LEVEL, 9)
 local creatureevent = CreatureEvent("PlayerLogin")
 
 function creatureevent.onLogin(player)
-	local loginStr = "Welcome to " .. configManager.getString(configKeys.SERVER_NAME) .. "!"
+	local loginStr = ""
 	if player:getLastLoginSaved() <= 0 then
-		loginStr = loginStr .. " Please choose your outfit."
+		loginStr = string.format("Welcome to %s! Please choose your outfit.", configManager.getString(configKeys.SERVER_NAME))
 		player:sendOutfitWindow()
 	else
 		if loginStr ~= "" then
 			player:sendTextMessage(MESSAGE_STATUS_DEFAULT, loginStr)
 		end
 
-		loginStr = string.format("Your last visit was on %s.", os.date("%a %b %d %X %Y", player:getLastLoginSaved()))
+		loginStr = string.format(
+		"Your last visit in %s: %s.",
+		configManager.getString(configKeys.SERVER_NAME),
+		os.date("%d. %b %Y %X %Z", player:getLastLoginSaved())
+	)
 	end
 	player:sendTextMessage(MESSAGE_STATUS_DEFAULT, loginStr)
 


### PR DESCRIPTION
I noticed a small detail while logging into the game world. The text displayed in the console when you log in for the first time does not match the actual login text from Tibia for first-time logins.

