### PR TITLE
fix(ci): Correct Ubuntu workflow paths and prevent cache/artifact collisions

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -44,7 +44,7 @@ jobs:
           languages: cpp
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           queries: +security-extended,security-and-quality
-        if: ${{ matrix.buildtype }} == "Debug"
+        if: matrix.buildtype == 'Debug' && matrix.luajit == 'on'
 
       - name: Get latest CMake
         # Using 'latest' branch, the latest CMake is installed.
@@ -68,10 +68,11 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:cpp"
-        if: ${{ matrix.buildtype }} == "Debug"
+        if: matrix.buildtype == 'Debug' && matrix.luajit == 'on'
 
       - name: Upload artifact binary
         uses: actions/upload-artifact@v6
+        if: matrix.buildtype == 'Release' && matrix.luajit == 'on'
         with:
-          name: ubuntu-tvp-amd64-${{ github.sha }}
-          path: ${{ runner.workspace }}/build/tvp
+          name: tvp
+          path: ${{ github.workspace }}/${{ matrix.buildtype }}

--- a/.github/workflows/build-vcpkg.yml
+++ b/.github/workflows/build-vcpkg.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - develop
       - v*
 
     paths:
@@ -13,13 +14,7 @@ on:
       - CMakePresets.json
       - vcpkg.json
 
-  pull_request:
-    paths:
-      - cmake/**
-      - src/**
-      - CMakeLists.txt
-      - CMakePresets.json
-      - vcpkg.json
+  workflow_dispatch:
 
 jobs:
   build-vcpkg:
@@ -42,7 +37,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Enable LuaJIT
-        if: ${{ matrix.luajit }} == "on"
+        if: matrix.luajit == 'on'
         run: echo "VCPKG_FEATURE_FLAGS=luajit" >> $GITHUB_ENV
 
       - name: Run vcpkg
@@ -57,19 +52,19 @@ jobs:
 
       - name: Upload artifact binary
         uses: actions/upload-artifact@v6
-        if: ${{ !startsWith(matrix.os, 'windows') }}
+        if: "!startsWith(matrix.os, 'windows')"
         with:
-          name: tvp-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
-          path: ${{ runner.workspace }}/build/tvp
+          name: tvp-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          path: ${{ github.workspace }}/build/${{ matrix.buildtype }}/tvp
 
       - name: Upload artifact binary (exe)
         uses: actions/upload-artifact@v6
-        if: ${{ startsWith(matrix.os, 'windows') }}
+        if: startsWith(matrix.os, 'windows')
         with:
-          name: tvp-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tvp-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: |
-            ${{ runner.workspace }}/build/tvp.exe
-            ${{ runner.workspace }}/build/*.dll
+            ${{ github.workspace }}/build/${{ matrix.buildtype }}/tvp.exe
+            ${{ github.workspace }}/build/${{ matrix.buildtype }}/*.dll
 
       - name: Prepare datapack contents
         run: find . -maxdepth 1 ! -name data ! -name config.lua.dist ! -name key.pem ! -name LICENSE ! -name README.md ! -name schema.sql -exec rm -r {} \;
@@ -78,5 +73,5 @@ jobs:
       - name: Upload datapack contents
         uses: actions/upload-artifact@v6
         with:
-          name: tvp-${{ matrix.name }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
+          name: tvp-${{ matrix.os }}-${{ matrix.buildtype }}-luajit=${{ matrix.luajit }}-${{ github.sha }}
           path: ${{ github.workspace }}


### PR DESCRIPTION
This change fixes incorrect Ubuntu workflow path filters and ensures that the cache and artifact
names do not collide across jobs and runs.
It also simplifies some of the syntax used.

Part of https://github.com/TVPV8/TVP/issues/8