### PR TITLE
fix: summons follows invisible player

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -822,7 +822,7 @@ void Monster::onIdleStimulus()
 			Target = nullptr;
 		}
 
-		if (attackedCreature && attackedCreature->isInvisible() && !canSeeInvisibility()) {
+		if (attackedCreature && attackedCreature->isInvisible() && !canSeeInvisibility() && attackedCreature != master) {
 			setAttackedCreature(nullptr);
 			Target = nullptr;
 		}


### PR DESCRIPTION
When you summon some monster ex. `utevo res "Demon Skeleton` and equip Stealth Ring, it does not follow you anymore.
This line change fixes it.

Reported by https://otland.net/members/jero_.172543/
He made fix for that in march, but I had no time to test it. Today I've tested his code (5 lines changed) and wrote shorter version.