### PR TITLE
docs: add issue templates for bug reports and feature requests (22)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Report a bug to help us improve
+title: '[BUG] '
+labels: 'bug'
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Current Behavior
+
+A clear and concise description of what actually happens.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+
+- OS: [e.g. Windows, macOS, Linux]
+- Browser: [e.g. Chrome, Firefox, Safari]
+- Version: [e.g. 22]
+
+## Additional Context
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Project Documentation
+    url: https://github.com/TVPV8/TVP/wiki
+    about: Check the documentation before opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[FEATURE] '
+labels: 'enhancement'
+assignees: ''
+---
+
+## Problem Statement
+
+Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, screenshots, or mockups about the feature request here.


### PR DESCRIPTION
This PR adds GitHub issue templates to improve the quality of incoming issues:

### Files added:

- **`.github/ISSUE_TEMPLATE/bug.md`** — Structured bug report template requiring:
  - Steps to reproduce
  - Expected vs. actual behavior
  - Environment details
  - Screenshots (optional)

- **`.github/ISSUE_TEMPLATE/feature.md`** — Feature request template requiring:
  - Problem statement
  - Proposed solution
  - Alternatives considered

- **`.github/ISSUE_TEMPLATE/config.yml`** — Configuration enabling blank issues and linking to documentation

These templates help contributors provide structured feedback and make it easier for maintainers to triage issues.

Closes #22